### PR TITLE
Fix ValueError: math domain error bug when area of triangle is zero.

### DIFF
--- a/alphashape/alphashape.py
+++ b/alphashape/alphashape.py
@@ -86,14 +86,19 @@ def alphashape(points, alpha=None):
         s = (a + b + c) * 0.5
 
         # Area of triangle by Heron's formula
-        area = math.sqrt(s * (s - a) * (s - b) * (s - c))
-
-        # Radius Filter
-        if area > 0 and a * b * c / (4.0 * area) < 1.0 / alpha:
-            for i, j in itertools.combinations([ia, ib, ic], r=2):
-                if (i, j) not in edges and (j, i) not in edges:
-                    edges.add((i, j))
-                    edge_points.append(coords[[i, j]])
+        # Precompute value inside square root to avoid unbound math error in case of 
+        # 0 area triangles. 
+        area = s * (s - a) * (s - b) * (s - c)
+        
+        if area > 0:
+            area = math.sqrt(area)
+            
+            # Radius Filter
+            if a * b * c / (4.0 * area) < 1.0 / alpha:
+                for i, j in itertools.combinations([ia, ib, ic], r=2):
+                    if (i, j) not in edges and (j, i) not in edges:
+                        edges.add((i, j))
+                        edge_points.append(coords[[i, j]])
 
     # Create the resulting polygon from the edge points
     m = MultiLineString(edge_points)


### PR DESCRIPTION
Hey,

Ran into a bug where I would get a ValueError: math domain error when triangle area are approaching zero. My guess is that precision error as the area of the triangle approaches zero meant that  s * (s-a)(s-b)(s-c) was evaluating to tiny negative value? Moving the positivity check before the square root fixed the problem. Figured I'd PR the fix so that it can make it back into the main repo.

Cheers for the work putting this together. 

Cheers,
Neil