### PR TITLE
Fix scaling-dependence of termination criterion

### DIFF
--- a/alphashape/optimizealpha.py
+++ b/alphashape/optimizealpha.py
@@ -97,7 +97,7 @@ def optimizealpha(points: Union[List[Tuple[float]], np.ndarray],
 
     # Begin the bisection loop
     counter = 0
-    while (upper - lower) > np.finfo(float).eps * 2:
+    while not np.isclose(lower, upper, atol=0.0, rtol=np.finfo(float).eps * 2):
         # Bisect the current bounds
         test_alpha = (upper + lower) * .5
 

--- a/tests/test_optimizealpha.py
+++ b/tests/test_optimizealpha.py
@@ -5,6 +5,7 @@
 
 
 import unittest
+import numpy as np
 
 from alphashape import optimizealpha
 
@@ -39,3 +40,25 @@ class TestOptimizeAlapha(unittest.TestCase):
                  (0.5, 0.25), (0.5, 0.75), (0.25, 0.5), (0.75, 0.5)],
                 max_iterations=2, lower=0.0, upper=1000.0)
         self.assertEqual(alpha, 0.0)
+
+    def test_large_alpha(self):
+        """
+        Given a polygon for which a large alpha is optimal, the optimizealpha
+        function should find a large alpha
+        """
+        scale = 1e30
+        alpha = optimizealpha(np.array(
+            [(0., 0.), (0., 1.), (1., 1.), (1., 0.),
+             (0.5, 0.25), (0.5, 0.75), (0.25, 0.5), (0.75, 0.5)]) / scale)
+        assert alpha > 3. * scale and alpha < 3.5 * scale
+
+    def test_tiny_alpha(self):
+        """
+        Given a polygon for which a tiny alpha is optimal, the optimizealpha
+        function should find a tiny alpha
+        """
+        scale = 1e-30
+        alpha = optimizealpha(np.array(
+            [(0., 0.), (0., 1.), (1., 1.), (1., 0.),
+             (0.5, 0.25), (0.5, 0.75), (0.25, 0.5), (0.75, 0.5)]) / scale)
+        assert alpha > 3. * scale and alpha < 3.5 * scale


### PR DESCRIPTION
The termination criterion for bisecting alpha implicitly assumes the optimal alpha to be in the order of magnitude of `1.0`. For larger values of alpha, `lower` and `upper` can never get close enough, meaning the bisection never terminates successfully. This happens already with an example like this:
```python
alpha = optimizealpha(
            [(0., 0.), (0., 0.1), (0.1, 0.1), (0.1, 0.),
             (0.05, 0.025), (0.05, 0.075), (0.025, 0.05), (0.075, 0.05)])
```
For smaller values of alpha, the bisection may terminate much too early, returning a very suboptimal alpha.

This fixes that by checking the relative instead of the absolute difference using `numpy.isclose`. Also, this adds tests with a large and a tiny optimal alpha that would have failed with the previous termination criterion.

An alternative might be to check `np.nextafter(lower, upper) == upper`, to ensure finding the exact threshold.

See also #18 . A user-defined tolerance as suggested there might be a good future addition. But for now, this change would at least make the function usable for larger alphas.